### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       env: coveralls=true
     - php: 7.1
     - php: 7.2
-#    - php: 7.3
+    - php: 7.3
     - php: nightly
   allow_failures:
     - php: nightly

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ static-analysis:
 	vendor/bin/phpstan.phar analyse -l 4 tests
 
 unit:
-	vendor/bin/phpunit tests/
+	vendor/bin/phpunit
 
 code-coverage:
 	vendor/bin/phpunit --coverage-html=coverage

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
+    "php": "^7.1"
   },
   "require-dev": {
     "phpstan/phpstan-shim": "@stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<phpunit
+    bootstrap="vendor/autoload.php"
+    colors="true">
+    <testsuite name="Json">
+        <directory>tests</directory>
+    </testsuite>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -19,6 +19,7 @@ class EncoderTest extends TestCase
         $json = '{';
 
         $this->expectException(\JsonException::class);
+        $this->expectExceptionMessage('Syntax error');
 
         Encoder::decode($json);
     }


### PR DESCRIPTION
# Changed log
- Remove comment `php-7.3` in Travis CI setting because this version is stable release and it should be tested.
- Add the `phpunit.xml` to define the PHPUnit test.
- Add the `expectExceptionMessage` method to check whether expected exception message is same as result exception message.