### PR TITLE
Appropriate PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "phpstan/phpstan-shim": "@stable",
-    "phpunit/phpunit": "@stable",
+    "phpunit/phpunit": "^7",
     "squizlabs/php_codesniffer": "@stable",
     "slevomat/coding-standard": "@stable"
   }


### PR DESCRIPTION
Last builds are failing, because `@stable` PHPUnit now is 8.x, and it's dropped PHP 7.1 support.

So for the supported versions PHPUnit 7 should be used.